### PR TITLE
Add tracking of @guardian/cdk usage (by querying Prism)

### DIFF
--- a/cdk/lib/gu-cdk-adoption.ts
+++ b/cdk/lib/gu-cdk-adoption.ts
@@ -23,13 +23,19 @@ export class GuCdkAdoption extends GuStack {
       description: "GitHub API token with repo permissions",
       fromSSM: true,
     });
+    const prismUrl = new GuStringParameter(this, "prism-url", {
+      fromSSM: true,
+    });
 
     const lambda = new GuScheduledLambda(this, "scheduled-lambda", {
       code: {
         bucket: bucketName.valueAsString,
         key: `${this.stack}/${this.stage}/${this.app}/${this.app}.zip`,
       },
-      environment: { API_TOKEN: apiToken.valueAsString },
+      environment: {
+        API_TOKEN: apiToken.valueAsString,
+        PRISM_URL: prismUrl.valueAsString
+      },
       functionName: `${this.app}-${this.stage}`,
       monitoringConfiguration: {
         toleratedErrorPercentage: 50,

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -3038,7 +3038,7 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -4535,7 +4535,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -5800,11 +5800,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -5813,32 +5808,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._root@~3.0.0:
   version "3.0.1"
@@ -5889,11 +5862,6 @@ lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"

--- a/lambda/package.json
+++ b/lambda/package.json
@@ -12,6 +12,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "aws-sdk": "^2.869.0"
+    "aws-sdk": "^2.869.0",
+    "axios": "^0.21.1"
   }
 }

--- a/lambda/src/handler.ts
+++ b/lambda/src/handler.ts
@@ -1,6 +1,7 @@
 import { Octokit } from "@octokit/rest";
 import { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods/dist-types/generated/parameters-and-response-types";
 import CloudWatch from "aws-sdk/clients/cloudwatch";
+import axios from "axios";
 
 if (!process.env["API_TOKEN"]) {
   throw new Error("No API_TOKEN envar for GitHub");
@@ -38,23 +39,50 @@ export async function handler() {
     value: reposUsingGuCdk.data.total_count,
   });
 
-  const usingAwsCdk = await octokit.search.code({
+  const reposUsingAwsCdk = await octokit.search.code({
     q: `user:guardian filename:package.json "@aws-cdk"`,
   });
-  console.log(`${usingAwsCdk.data.total_count} using @aws-cdk/core`);
+  console.log(`${reposUsingAwsCdk.data.total_count} using @aws-cdk/core`);
   await putMetric({
     name: "Repositories using @aws-cdk/core",
-    value: usingAwsCdk.data.total_count,
+    value: reposUsingAwsCdk.data.total_count,
   });
 
-  const usingCfn = await octokit.search.code({
+  const reposUsingCloudFormation = await octokit.search.code({
     q: `user:guardian filename:"cloudformation.yaml" filename:"cloudformation.yml" filename:"cfn.yaml" filename:"cfn.yml"`,
   });
-  console.log(`${usingCfn.data.total_count} using cloudformation`);
+  console.log(`${reposUsingCloudFormation.data.total_count} using cloudformation`);
   await putMetric({
     name: "Repositories using Cloudformation",
-    value: usingCfn.data.total_count,
+    value: reposUsingCloudFormation.data.total_count,
   });
+
+  interface AppWithCoreTags {
+    app: string;
+    stack: string;
+    stage: string;
+    guCdkVersion: string;
+  }
+  
+  const prismResponse = await axios.get(`${process.env.PRISM_URL}/apps-with-cdk-version`);
+  const allApps: AppWithCoreTags[] = prismResponse.data.data['apps-with-cdk-version']
+  const appsUsingGuCdk = allApps.filter(app => app.guCdkVersion != "n/a")
+
+  const numberOfAppsAlreadyUsingGuCdk = appsUsingGuCdk.length
+  const numberOfAppsLeftToMigrate = allApps.length - appsUsingGuCdk.length
+
+  console.log(`Prism data shows that ${numberOfAppsAlreadyUsingGuCdk} apps are using @guardian/cdk.`)
+  await putMetric({
+    name: "Apps using @guardian/cdk",
+    value: numberOfAppsAlreadyUsingGuCdk,
+  });
+
+  console.log(`Prism data shows that there are ${numberOfAppsLeftToMigrate} apps left to migrate.`)
+  await putMetric({
+    name: "Apps which need to migrate to @guardian/cdk",
+    value: numberOfAppsLeftToMigrate,
+  });
+
 }
 
 if (require.main === module) {

--- a/lambda/src/handler.ts
+++ b/lambda/src/handler.ts
@@ -20,7 +20,7 @@ async function putMetric({ name, value }: { name: string; value: number }) {
           Value: value,
         },
       ],
-      Namespace: "GitHub",
+      Namespace: "gu-cdk-adoption",
     })
     .promise();
   console.log("putMetricData response", pmd);

--- a/lambda/yarn.lock
+++ b/lambda/yarn.lock
@@ -130,6 +130,13 @@ aws-sdk@^2.869.0:
     uuid "3.3.2"
     xml2js "0.4.19"
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 base64-js@^1.0.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -173,6 +180,11 @@ events@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
+follow-redirects@^1.10.0:
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.3.tgz#e5598ad50174c1bc4e872301e82ac2cd97f90267"
+  integrity sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==
 
 ieee754@1.1.13:
   version "1.1.13"


### PR DESCRIPTION
## What does this change?

We can now track the adoption of `@guardian/cdk` via Prism. See https://github.com/guardian/prism/pull/168 for more details.

## How to test

This change is already in `PROD`, because I needed to test it somewhere! 😅 

## How can we measure success?

We should be able to add these new metrics to our tracking dashboard!

## Have we considered potential risks?

I think this is pretty low risk. More generally, we should probably set up CI, CD and a `CODE` environment for this project to make it possible to work on this project without breaking `PROD`. However, the impact of a `PROD` breakage is very small, so I think this manual approach is fine for now.